### PR TITLE
Fix typos and run go fmt

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"net/http"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"net/http"
 )
 
 // handlerFunc can be used as handler for http.HandleFunc()

--- a/job.go
+++ b/job.go
@@ -132,10 +132,10 @@ func (j *Job) Run() {
 				level.Error(j.log).Log("msg", "Failed to run", "err", err)
 			}
 
-			// send to done chanel
+			// send true into done channel
 			j.Done <- true
 		} else {
-			// interval is grater than 0 so procide with async operation
+			// interval is grater than 0, so proceed with an async operation
 			bo := backoff.NewExponentialBackOff()
 			bo.MaxElapsedTime = j.Interval
 			if err := backoff.Retry(j.runOnce, bo); err != nil {


### PR DESCRIPTION
This commit corrects two typos in the comments.
Furthermore I ran go fmt, which fixed the formatting in handler.go.