### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 prometheus-sql-exporter (0.2.0.ds-7) UNRELEASED; urgency=medium
 
   * Drop unnecessary dh arguments: --with=systemd
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 13:51:49 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+prometheus-sql-exporter (0.2.0.ds-7) UNRELEASED; urgency=medium
+
+  * Drop unnecessary dh arguments: --with=systemd
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 13:51:49 +0000
+
 prometheus-sql-exporter (0.2.0.ds-6) unstable; urgency=medium
 
   * Update PostgreSQL Maintainers address.

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends: debhelper (>= 10),
  golang-github-go-kit-kit-dev,
  help2man,
  dh-golang,
-Standards-Version: 4.3.0
+Standards-Version: 4.5.0
 Homepage: https://github.com/credativ/sql_exporter
 XS-Go-Import-Path: github.com/credativ/sql_exporter
 Vcs-Browser: https://github.com/credativ/sql_exporter

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with=systemd --with=golang --buildsystem=golang
+	dh $@ --with=golang --buildsystem=golang
 
 override_dh_auto_install:
 	mv obj-$(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)/bin/sql_exporter \


### PR DESCRIPTION
Fix some issues reported by lintian
* Drop unnecessary dh arguments: --with=systemd ([debian-rules-uses-unnecessary-dh-argument](https://lintian.debian.org/tags/debian-rules-uses-unnecessary-dh-argument.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/prometheus-sql-exporter/cfa61b4d-6947-4713-95d7-57d471eef72c.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Built-Using: golang-github-beorn7-perks (= [-1.0.1-1~jan+unchanged1),-] {+1.0.1-2~jan+lint1),+} golang-github-cenkalti-backoff (= 3.1.1-1), [-golang-github-cespare-xxhash (= 2.1.1-1),-] golang-github-denisenkom-go-mssqldb (= [-0.0~git20170717.0.8fccfc8-6~jan+unchanged1),-] {+0.0~git20170717.0.8fccfc8-6~jan+lint2),+} golang-github-go-kit-kit (= [-0.6.0-3~jan+unchanged1),-] {+0.6.0-3~jan+lint3),+} golang-github-go-logfmt-logfmt (= [-0.3.0-1),-] {+0.3.0-2~jan+lint3),+} golang-github-go-sql-driver-mysql (= [-1.4.1-1),-] {+1.4.1-2~jan+lint2),+} golang-github-go-stack-stack (= 1.8.0-1), golang-github-jmoiron-sqlx (= [-1.1+git20160206.61.398dd58-3~jan+unchanged1),-] {+1.1+git20160206.61.398dd58-3~jan+lint3),+} golang-github-lib-pq (= 1.3.0-1), golang-github-prometheus-client-golang (= [-1.2.1-3),-] {+0.9.0-2~jan+lint1),+} golang-github-prometheus-client-model (= 0.0.2+git20171117.99fa1f4-1), golang-github-prometheus-common (= [-0.7.0-1),-] {+0.7.0-2~jan+lint1),+} golang-go.crypto (= 1:0.0~git20200429.4b2356b-1), [-golang-golang-x-net-] {+golang-golang-x-net-dev+} (= [-1:0.0+git20200226.491c5fc+dfsg-1),-] {+1:0.0+git20190811.74dc4d7+dfsg-2~jan+lint1),+} golang-goprotobuf (= 1.3.4-2), golang-procfs (= [-0.0.10-2~jan+unchanged1),-] {+0.0.10-2~jan+lint1),+} golang-protobuf-extensions (= 1.0.1-1), golang-yaml.v2 (= 2.2.8-2)


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/cfa61b4d-6947-4713-95d7-57d471eef72c/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/cfa61b4d-6947-4713-95d7-57d471eef72c/diffoscope)).
